### PR TITLE
Replaced JWPlayer with video.js player 

### DIFF
--- a/index.php
+++ b/index.php
@@ -74,10 +74,8 @@ $spooks = (date('m') == 10 && date('d') == 31);
 		</div>
 		<div id="content">
 			<div id="playerError"></div>
-			<div id="video">
-				<video-js id=vid1 class="vjs-default-skin vjs-fluid" controls>
+				<video-js id="video" class="vjs-default-skin vjs-fill" controls>
 				</video-js>
-			</div>
 			<div id="chat"<?= ($chatHidden ? ' class="hidden" style="width:0px; background-color:rgba(61, 167, 60, 0);"' : ' style="width:' . $chatSize . 'px;"') ?>>
 				<iframe src="https://webchat.quakenet.org/?channels=dopefish_lives&amp;uio=<?= ($spooks ? 'MTE9MA4c' : 'MTE9MTAz8d') ?>" class="fullContentHeight"></iframe>
 				<a id="expand" href="javascript:;" onclick="expandStream();"></a>

--- a/index.php
+++ b/index.php
@@ -9,8 +9,6 @@ if (isset($_COOKIE['chatsize'])) {
 
 $vackerPromo = false;
 $spooks = (date('m') == 10 && date('d') == 31);
-
-$hls = !($_GET['hls'] == 'false' || isset($_GET['flash']));
 ?><!DOCTYPE html>
 <html>
 
@@ -30,16 +28,9 @@ $hls = !($_GET['hls'] == 'false' || isset($_GET['flash']));
 		<script src="https://code.jquery.com/ui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
 		<link rel="stylesheet" type="text/css" href="https://code.jquery.com/ui/1.11.4/themes/black-tie/jquery-ui.css" />
 		<link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-		
-		<? if ($hls) { ?>
-				<script src="https://content.jwplatform.com/libraries/<?= ($spooks ? '0LjSzsNc' : 'i2wbg4Bq') ?>.js"></script>
-		<? } else { ?>
-				<script src="script/jwplayer-7.12.13.js"></script>
-		<? } ?>
-		<script>
-				jwplayer.key="b3eA3XrzNeYTKIscnX3RJQKfYGPDtXzXSoYDVw==";
-				var hls = <?= $hls ? 'true' : 'false' ?>;
-		</script>
+
+		<link href="https://vjs.zencdn.net/8.19.1/video-js.min.css" rel="stylesheet">
+    	<script src="https://vjs.zencdn.net/8.19.1/video.min.js"></script>
 		
 		<script src="script/functions.js"></script>
 		<script src="script/watch.js"></script>
@@ -84,7 +75,8 @@ $hls = !($_GET['hls'] == 'false' || isset($_GET['flash']));
 		<div id="content">
 			<div id="playerError"></div>
 			<div id="video">
-				<div id="flash"></div>
+				<video-js id=vid1 class="vjs-default-skin vjs-fluid" controls>
+				</video-js>
 			</div>
 			<div id="chat"<?= ($chatHidden ? ' class="hidden" style="width:0px; background-color:rgba(61, 167, 60, 0);"' : ' style="width:' . $chatSize . 'px;"') ?>>
 				<iframe src="https://webchat.quakenet.org/?channels=dopefish_lives&amp;uio=<?= ($spooks ? 'MTE9MA4c' : 'MTE9MTAz8d') ?>" class="fullContentHeight"></iframe>

--- a/script/script.js
+++ b/script/script.js
@@ -102,7 +102,7 @@ $(function() {
         controlBar.children(".jw-icon-fullscreen").before('<div class="jw-icon jw-icon-inline jw-button-color jw-reset fa fa-external-link"></div>');
         $(".fa-external-link").click(function() {
             player.pause();
-            window.open('watch.php' + (hls ? '?hls' : ''),'popout','width=1280,height=720,location=0,menubar=0,scrollbars=0,status=0,toolbar=0,resizable=1');
+            window.open('watch.php','popout','width=1280,height=720,location=0,menubar=0,scrollbars=0,status=0,toolbar=0,resizable=1');
         });
         
         // doesn't work with new button

--- a/script/script.js
+++ b/script/script.js
@@ -16,6 +16,7 @@ var expandButton;
 
 var resizing;
 var prevWidth;
+var expandedToggle = false;
 
 var mainRgb = "61, 167, 60";
 
@@ -104,19 +105,10 @@ $(function() {
             window.open('watch.php' + (hls ? '?hls' : ''),'popout','width=1280,height=720,location=0,menubar=0,scrollbars=0,status=0,toolbar=0,resizable=1');
         });
         
+        // doesn't work with new button
         // Handle the expand/shrink button
-        controlBar.append('<div class="jw-icon jw-icon-inline jw-button-color jw-reset fa fa-expand"></div>');
-        expandButton = $(".fa-expand");
-        if (chatSize == 0) {
-            expandButton.addClass("jw-off");
-        }
-        expandButton.click(function() {
-            if (expandButton.hasClass("jw-off")) {
-                shrinkStream();
-            } else {
-                expandStream();
-            }
-        });
+        //controlBar.append('<div class="jw-icon jw-icon-inline jw-button-color jw-reset fa fa-expand"></div>');
+        expandButton = $(".toggle-size-button");
         
         resizeWindow();
     });
@@ -179,6 +171,16 @@ function shrinkStream() {
     });
     
     setCookie(chatSizeCookie, originalChatWidth);
+}
+
+function toggleStream() {
+    if(expandedToggle) {
+        shrinkStream()
+        expandedToggle = false
+    } else {
+        expandStream()
+        expandedToggle = true
+    }
 }
 
 function resizeWindow(manual) {

--- a/script/watch.js
+++ b/script/watch.js
@@ -18,7 +18,8 @@ function initPlayer(onReady, sources, showError) {
     jwOnReady = onReady;
     
     // Prepare Video.js player
-    player = videojs('vid1');
+    player = videojs('video');
+    player.ready(onReady);
 
     // works, but breaks with code in script.js
     // //player.controlBar.addChild('button', {}, 0) //adds to beginning of controls
@@ -34,7 +35,7 @@ function initPlayer(onReady, sources, showError) {
 };
 
 function displayPlayerError() {
-    playerError.html('Could not start stream.' + (!hls ? ' Either ensure <a href="https://get.adobe.com/flashplayer/" target="_blank">Flash</a> is enabled or <a href="?hls">go to our HTML5 stream</a>.' : ''));
+    playerError.html('Could not start stream.');
     playerError.show();
     // Need a timeout because JW Player will try to set the error message after the error callback.
     setTimeout(function() {
@@ -144,17 +145,8 @@ function setStreamUrl(url) {
     setStreamSources(sources);
 }
 function setStreamSources(sources) {
-    if (hls) {
-        // Can't just load new sources in newer JW Player versions because they went full cash-grab mode
-        initPlayer(jwOnReady, sources);
-    } else {
-        player.load([{
-            sources: sources
-        }]);
-        if (playing) {
-            player.play();
-        }
-    }
+    // Can't just load new sources in newer JW Player versions because they went full cash-grab mode
+    initPlayer(jwOnReady, sources);
     
     updateInfoPane();
 }
@@ -185,9 +177,5 @@ function getCookie(name) {
 }
 
 function getStreamUrl(server, channel) {
-    if (hls) {
-        return "https://" + server + ".vacker.tv/" + (server != "uk" ? "hls/" : "") + channel + "/" + (server == "uk" ? "live" : "index") + ".m3u8";
-    } else {
-        return "rtmp://" + server + ".vacker.tv/" + channel + "/" + channel;
-    }
+    return "https://" + server + ".vacker.tv/" + (server != "uk" ? "hls/" : "") + channel + "/" + (server == "uk" ? "live" : "index") + ".m3u8";
 }

--- a/script/watch.js
+++ b/script/watch.js
@@ -17,84 +17,20 @@ function initPlayer(onReady, sources, showError) {
     playerError = $("#playerError");
     jwOnReady = onReady;
     
-    var hdCookieSetting = getCookie(hdCookie);
-    hd = (hdCookieSetting ? hdCookieSetting == "on" : true);
+    // Prepare Video.js player
+    player = videojs('vid1');
 
-    // Prepare JW player
-    player = jwplayer("flash");
-    player.setup({
-        file: getStreamUrl(defaultServer, (enableAutoplay ? "autoplay" : "live")),
-        sources: sources,
-        image: (showError ? "images/nostreams.png" : null),
-        width: "100%",
-        height: "100%",
-        stretching: "uniform",
-        liveTimeout: 0
-    })
-    .on("ready", function() {
-        // Handle the stream info
-        var controlBar = $(".jw-controlbar-right-group");
-        infoPane = $(".jw-controlbar-center-group, .jw-text-live");
-        infoPane.show();
-        updateInfoPane();
-        
-        // Handle the HD button
-        if (enableHdToggle) {
-            $(".jw-icon-hd").remove();
-            controlBar.prepend('<div class="jw-icon jw-icon-inline jw-button-color jw-reset jw-icon-hd' + (!isLive ? " jw-hidden" : "") + '">\
-                <div id="hd-led" class="fa fa-circle"></div>\
-            </div>');
-            hdButton = $(".jw-icon-hd");
-            if (!hd) {
-                hdButton.addClass("jw-off");
-            }
-            hdButton.mouseenter(function() {
-                hdButton.addClass("jw-open");
-            });
-            hdButton.mouseleave(function() {
-                hdButton.removeClass("jw-open");
-            });
-            hdButton.click(function() {
-                if (hdButton.hasClass("jw-off")) {
-                    enableHd();
-                } else {
-                    disableHd();
-                }
-            });
-        }
-        
-        if (onReady) {
-            onReady();
-        }
-    
-        // Start the player
-        autoswitch();
-        autoswitchInterval = setInterval(function() {
-            autoswitch();
-        }, 5000);
-    })
-    .on("play", function() {
-        playerError.hide();
-        playing = true;
-    })
-    .on("pause", function() {
-        playing = false;
-    })
-    .on("complete", function() {
-        autoswitch();
-    })
-    .on("setupError", function(error) {
-        if (error.message == "Error loading player: No playable sources found") {
-            displayPlayerError();
-        }
-    })
-    .on("error", function(error) {
-        if (error.message == "Flash plugin failed to load") {
-            displayPlayerError();
-        } else if (error.code = 232011) {
-            initPlayer(jwOnReady, sources, true);
-        }
-    });
+    // works, but breaks with code in script.js
+    // //player.controlBar.addChild('button', {}, 0) //adds to beginning of controls
+    // var toggleSizeButton = player.controlBar.addChild('button');
+    // var toggleSizeButtonDom = toggleSizeButton.el();
+    // toggleSizeButtonDom.class = 'toggle-size-button';
+    // toggleSizeButtonDom.innerHTML = 'Chat';
+    // toggleSizeButtonDom.onclick = () => {
+    //     toggleStream();
+    // }
+
+    player.addSourceElement(getStreamUrl(defaultServer, (enableAutoplay ? "autoplay" : "live")), "application/x-mpegURL");
 };
 
 function displayPlayerError() {
@@ -104,19 +40,6 @@ function displayPlayerError() {
     setTimeout(function() {
         $(".jw-title-primary").html('');
     }, 1);
-}
-
-function enableHd() {
-    hdButton.removeClass("jw-off");
-    hd = true;
-    autoswitch();
-    setCookie(hdCookie, "on");
-}
-function disableHd() {
-    hdButton.addClass("jw-off");
-    hd = false;
-    autoswitch();
-    setCookie(hdCookie, "off");
 }
 
 

--- a/style/layout.css
+++ b/style/layout.css
@@ -7,6 +7,8 @@
 body {
 	background-color:#0e0e0e;
 	margin: 0px;
+	display: flex;
+	flex-flow: column;
 }
 
 
@@ -111,6 +113,7 @@ body {
 	display:table;
 	table-layout: fixed;
 	position:relative;
+	flex: 1 1 auto;
 }
 
 #playerError {

--- a/watch.php
+++ b/watch.php
@@ -1,6 +1,4 @@
-<?
-$hls = isset($_GET['hls']);
-?><!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 
 	<head>
@@ -14,15 +12,8 @@ $hls = isset($_GET['hls']);
 		<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
 		
-		<? if ($hls) { ?>
-			<script src="https://content.jwplatform.com/libraries/i2wbg4Bq.js"></script>
-		<? } else { ?>
-			<script src="script/jwplayer-7.12.13.js"></script>
-		<? } ?>
-		<script>
-			jwplayer.key="b3eA3XrzNeYTKIscnX3RJQKfYGPDtXzXSoYDVw==";
-			var hls = <?= $hls ? 'true' : 'false' ?>;
-		</script>
+		<link href="https://vjs.zencdn.net/8.19.1/video-js.min.css" rel="stylesheet">
+		<script src="https://vjs.zencdn.net/8.19.1/video.min.js"></script>
 		
 		<script src="script/functions.js"></script>
 		<script src="script/watch.js"></script>
@@ -35,6 +26,7 @@ $hls = isset($_GET['hls']);
 	</head>
 
 	<body>
-		<div id="flash"></div>
+		<video-js id="video" class="vjs-default-skin vjs-fill" controls>
+		</video-js>
 	</body>
 </html>


### PR DESCRIPTION
Replaces JWPlayer with video.js. Necessary because JWPlayer is now paid-only.

Based on https://github.com/fre-db/dopelives/pull/8, with a few fixes:
* Removes leftover `hls` calls (variable was removed).
* Restored `onReady` call.
* Fixes chat resize.
* Aligns `watch.php`.

Still missing:
* Player error handling (such as when not live).
* The expand/collapse chat button.
* Topic information.
* Autoswitching between servers (probably not needed and can be removed).