### PR TITLE
Display custom error message when not live

### DIFF
--- a/script/watch.js
+++ b/script/watch.js
@@ -20,6 +20,12 @@ function initPlayer(onReady, sources, showError) {
     // Prepare Video.js player
     player = videojs('video');
     player.ready(onReady);
+    player.on('error', function(e) {
+        var error = player.error();
+        if (error.code == 4) {
+            displayNotLiveError();
+        }
+    });
 
     // works, but breaks with code in script.js
     // //player.controlBar.addChild('button', {}, 0) //adds to beginning of controls
@@ -36,13 +42,13 @@ function initPlayer(onReady, sources, showError) {
     });
 };
 
-function displayPlayerError() {
-    playerError.html('Could not start stream.');
+function displayNotLiveError() {
+    displayPlayerError('No one is currently streaming.');
+}
+function displayPlayerError(message) {
+    playerError.html(message);
     playerError.show();
-    // Need a timeout because JW Player will try to set the error message after the error callback.
-    setTimeout(function() {
-        $(".jw-title-primary").html('');
-    }, 1);
+    $('.vjs-error-display').hide();
 }
 
 


### PR DESCRIPTION
Clarified cryptic error message shown when opening the site while no one is live.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/f3dc08da-37e6-4fe1-8a7f-96884594db7d) | ![image](https://github.com/user-attachments/assets/90bc46da-7802-4cdc-960d-1a587427ca4b) |