### PR TITLE
Allow retrying starting stream

### DIFF
--- a/script/watch.js
+++ b/script/watch.js
@@ -40,6 +40,13 @@ function initPlayer(onReady, sources, showError) {
       type: 'application/x-mpegURL',
       src: getStreamUrl(defaultServer, (enableAutoplay ? "autoplay" : "live"))
     });
+    
+    // Allow play button to retry stream.
+    $('.vjs-play-control').on('click', function(e) {
+        if ($('#video').hasClass('vjs-error')) {
+            player.load();
+        }
+    });
 };
 
 function displayNotLiveError() {
@@ -49,6 +56,9 @@ function displayPlayerError(message) {
     playerError.html(message);
     playerError.show();
     $('.vjs-error-display').hide();
+    
+    $('.vjs-control-bar').show();
+    $('.vjs-controls-disabled').removeClass('vjs-controls-disabled');
 }
 
 

--- a/style/watch.css
+++ b/style/watch.css
@@ -90,6 +90,10 @@ body {
 }
 
 
+/* Keep UI available when not live. */
+#video.vjs-error .vjs-control-bar {
+    display:block !important;
+}
 
 
 


### PR DESCRIPTION
Keep the control bar visible when failing to load stream, and allow let the play button reload the player.

This lets users tune in when the stream goes live and gives a surface to add controls that are useful even when not live. E.g., topic info and a collapse/expand chat button.

![image](https://github.com/user-attachments/assets/8b1d3d93-1fb8-4512-ac2f-536b51bf0da5)
