### PR TITLE
Restored popout and expand buttons

### DIFF
--- a/script/script.js
+++ b/script/script.js
@@ -13,6 +13,7 @@ var fadeElements;
 var originalChatWidth = 500;
 
 var expandButton;
+var expandButtonCollapsedClass = 'vjs-expand-collapsed';
 
 var resizing;
 var prevWidth;
@@ -63,7 +64,7 @@ $(function() {
         start: function(event, ui) {
             resizing = true;
             if (prevWidth < 150) {
-                expandButton.removeClass("jw-off");
+                expandButton.removeClass(expandButtonCollapsedClass);
                 header.removeClass("hidden");
                 chat.removeClass("hidden");
             }
@@ -91,24 +92,28 @@ $(function() {
     });
     
     initPlayer(function() {
-        var controlBar = $(".jw-button-container, .jw-controlbar-right-group");
-        
-        // Handle the JW Player size
-        var jwAspect = $(".jw-aspect");
-        jwAspect.css("paddingTop", "");
-        fullContentHeights = $(".fullContentHeight").add(jwAspect);
+        var controlBar = $(".vjs-control-bar");
         
         // Handle the expand/shrink button
-        controlBar.children(".jw-icon-fullscreen").before('<div class="jw-icon jw-icon-inline jw-button-color jw-reset fa fa-external-link"></div>');
+        controlBar.children(".vjs-fullscreen-control").before('<button class="vjs-popout vjs-control vjs-button" type="button" title="Popout"><span class="vjs-icon-placeholder fa fa-external-link"></span><span class="vjs-control-text" aria-live="polite">Popout</span></button>');
         $(".fa-external-link").click(function() {
             player.pause();
             window.open('watch.php','popout','width=1280,height=720,location=0,menubar=0,scrollbars=0,status=0,toolbar=0,resizable=1');
         });
         
-        // doesn't work with new button
         // Handle the expand/shrink button
-        //controlBar.append('<div class="jw-icon jw-icon-inline jw-button-color jw-reset fa fa-expand"></div>');
-        expandButton = $(".toggle-size-button");
+        controlBar.append('<button class="vjs-expand vjs-control vjs-button" type="button" title="Toggle chat"><span class="vjs-icon-placeholder fa fa-expand"></span><span class="vjs-control-text" aria-live="polite">Toggle chat</span></button>');
+        expandButton = $(".vjs-expand");
+        if (chatSize == 0) {
+            expandButton.addClass(expandButtonCollapsedClass);
+        }
+        expandButton.click(function() {
+            if (expandButton.hasClass(expandButtonCollapsedClass)) {
+                shrinkStream();
+            } else {
+                expandStream();
+            }
+        });
         
         resizeWindow();
     });
@@ -132,7 +137,7 @@ $(function() {
     });
 });
 function expandStream() {
-    if (expandButton) expandButton.addClass("jw-off");
+    if (expandButton) expandButton.addClass(expandButtonCollapsedClass);
     
     prevWidth = 0;
     header.animate({ height: 0, opacity: 0 });
@@ -152,7 +157,7 @@ function expandStream() {
     setCookie(chatSizeCookie, 0);
 }
 function shrinkStream() {
-    if (expandButton) expandButton.removeClass("jw-off");
+    if (expandButton) expandButton.removeClass(expandButtonCollapsedClass);
     prevWidth = originalChatWidth;
     
     header.removeClass("hidden");

--- a/script/watch.js
+++ b/script/watch.js
@@ -11,7 +11,9 @@ function initPlayer(onReady, sources, showError) {
     
     // Prepare Video.js player
     player = videojs('video');
-    player.ready(onReady);
+    if (onReady) {
+        player.on('ready', onReady);
+    }
     player.on('error', function(e) {
         var error = player.error();
         if (error.code == 4) {
@@ -22,15 +24,6 @@ function initPlayer(onReady, sources, showError) {
         playerError.hide();
     });
 
-    // works, but breaks with code in script.js
-    // //player.controlBar.addChild('button', {}, 0) //adds to beginning of controls
-    // var toggleSizeButton = player.controlBar.addChild('button');
-    // var toggleSizeButtonDom = toggleSizeButton.el();
-    // toggleSizeButtonDom.class = 'toggle-size-button';
-    // toggleSizeButtonDom.innerHTML = 'Chat';
-    // toggleSizeButtonDom.onclick = () => {
-    //     toggleStream();
-    // }
     player.src({
       type: 'application/x-mpegURL',
       src: getStreamUrl()
@@ -63,8 +56,7 @@ var liveInfo;
 function autoswitch() {
     $.ajax({
         type: "GET",
-        // Use DE instead of UK to check status since UK doesn't report it.
-        url: "https://de.vacker.tv/json.php",
+        url: "https://vacker.tv/json.php",
         dataType: "json",
         success: function(data) {
             isLive = data.live.live;

--- a/style/font.css
+++ b/style/font.css
@@ -10,13 +10,6 @@ body {
     color:#777;
 }
 body,
-#flash .jw-controlbar-center-group,
-#flash .jw-text-elapsed,
-#flash .jw-text-live {
-    font-family: Century Gothic, CenturyGothic, AppleGothic, CG, sans-serif;
-    font-size: 16px;
-    text-transform:none;
-}
 input {
     font-family: Century Gothic, CenturyGothic, AppleGothic, CG, sans-serif;
     font-size: 14px;

--- a/style/layout.css
+++ b/style/layout.css
@@ -134,12 +134,6 @@ body {
     background-color:#000;
     line-height:0;
 }
-#flash.jwplayer {
-    height:auto !important;
-}
-#flash.jwplayer .jw-aspect {
-    display:block;
-}
 
 
 #chat {

--- a/style/spooks.css
+++ b/style/spooks.css
@@ -32,10 +32,7 @@
     font-style: normal;
 }
 
-body,
-#flash .jw-controlbar-center-group,
-#flash .jw-text-elapsed,
-#flash .jw-text-live {
+body {
     font-family:Spook,Century Gothic,CenturyGothic,AppleGothic,CG,sans-serif;
 }
 

--- a/style/watch.css
+++ b/style/watch.css
@@ -11,70 +11,32 @@ body {
 
 
 
-#flash {
-    width:100%;
-    height:100% !important;
-}
-.jw-media object {
-    width:100%;
-    height:100%;
-}
-.jw-tab-focus:focus {
-    outline: none !important;
-}
-#flash .jw-slider-time, #flash .jw-text-duration {
-    display:none;
-}
-#flash.jwplayer.jw-state-idle .jw-controlbar, #flash.jwplayer.jw-state-error .jw-controlbar {
-  display: flex !important;
-}
-#flash .jw-controlbar-center-group {
-    max-width:0;
-}
-#flash .jw-controlbar-center-group, #flash .jw-text-elapsed {
-    font-family: Century Gothic, CenturyGothic, AppleGothic, CG, sans-serif;
-    white-space:nowrap;
-    overflow:hidden;
-    text-overflow:ellipsis;
-}
-#flash .jw-rightclick {
-    display:none !important;
-}
-.jw-skin-seven .jw-controlbar-right-group .jw-icon-tooltip::before, .jw-skin-seven .jw-controlbar-right-group .jw-icon-inline::before {
-    border-left:none !important;
-}
-.fa {
-    font-family:FontAwesome !important;
-}
-.jw-button-container .fa-expand {
-    font-size:35px !important;
-}
 .fa-expand::before {
     content:"" !important;
 }
-.fa-expand.jw-off::before {
+.vjs-expand-collapsed .fa-expand::before {
     content:"" !important;
 }
+.vjs-popout, .vjs-expand {
+    cursor:pointer;
+}
 .fa-external-link {
-    line-height:35px !important;
+    font-size:7px !important;
 }
-.jw-button-container .fa-external-link {
-    font-size:20px !important;
-}
-.jw-logo-button {
-    display:none !important;
-}
-.jw-text-live {
-    width:auto !important;
-}
-.jw-text-live::before {
-    display:none !important;
+.fa:before {
+    line-height:30px !important;
 }
 
 
 /* Keep UI available when not live. */
 #video.vjs-error .vjs-control-bar {
-    display:block !important;
+    display:flex !important;
+}
+#video.vjs-error .vjs-progress-holder, #video.vjs-error .vjs-remaining-time {
+    display:none !important;
+}
+#video.vjs-error .vjs-progress-control {
+    cursor:default !important;
 }
 
 


### PR DESCRIPTION
- Restored control bar button that lets users open the stream in a minimal popout window.
- Restored control bar button that toggles the chat.
- Fixed control bar positioning issues when not live.
- Removed outdated JWPlayer CSS.
- [Used recommended Vacker server for fetching live status.](https://github.com/fre-db/dopelives/pull/14#discussion_r1845409105)

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/05d43170-7535-4e5c-9b51-e5d08c559afa) | ![image](https://github.com/user-attachments/assets/c3836925-404e-4127-825a-d0dd337f4ca2) |