### PR TITLE
Immediately play after retrying when live

### DIFF
--- a/script/watch.js
+++ b/script/watch.js
@@ -33,7 +33,7 @@ function initPlayer(onReady, sources, showError) {
     $('.vjs-play-control').on('click', function(e) {
         if ($('#video').hasClass('vjs-error')) {
             playerError.hide();
-            player.load();
+            player.play();
         }
     });
 };


### PR DESCRIPTION
Prevents the user from manually having to press the big play button after pressing the small one to reload the player. Reloading the player itself doesn't appear needed, but it's hard to test so to be confirmed later.